### PR TITLE
Running the python script requires a bit more

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -13,6 +13,7 @@ You will need Python 3 (`brew install python3`).
 Installing the dependencies:
 
 ```bash
+brew install cairo
 pip3 install -r requirements.txt
 ```
 

--- a/logo/requirements.txt
+++ b/logo/requirements.txt
@@ -1,2 +1,3 @@
 click
 cairosvg
+lxml


### PR DESCRIPTION
To run the `logo.py` script you also need:
- the `cairo` binary
- the `lxml` package